### PR TITLE
電話番号認証

### DIFF
--- a/ios/kamatte/Info.plist
+++ b/ios/kamatte/Info.plist
@@ -20,6 +20,17 @@
 	<string>1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>com.googleusercontent.apps.746512155399-96hrdvegeeu8lh8517pctno5icrjn9iv</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react-native": "0.61.2",
     "react-native-firebase": "^5.5.6",
     "react-native-gifted-chat": "^0.11.0",
+    "react-native-phone-input": "^0.2.4",
     "react-native-router-flux": "^4.0.6",
     "react-native-vector-icons": "^6.6.0"
   },

--- a/src/Root.js
+++ b/src/Root.js
@@ -2,14 +2,16 @@ import React from "react";
 import { Router, Stack, Scene } from "react-native-router-flux";
 
 import sample from "app/src/components/lv5/sample";
-import chatRoom from "app/src/components/lv5/chatRoom";
+import Chatroom from "app/src/components/lv5/Chatroom";
+import Register from "app/src/components/lv5/Register";
 
 const Root = () => {
   return (
     <Router>
       <Stack key="root">
-        <Scene key="chatRoom" component={chatRoom} title="chatroom" />
         <Scene key="sample" component={sample} title="sample" />
+        <Scene key="chatroom" component={Chatroom} title="chatroom" />
+        <Scene key="register" component={Register} title="新規登録" />
       </Stack>
     </Router>
   );

--- a/src/Root.js
+++ b/src/Root.js
@@ -4,6 +4,7 @@ import { Router, Stack, Scene } from "react-native-router-flux";
 import sample from "app/src/components/lv5/sample";
 import Chatroom from "app/src/components/lv5/Chatroom";
 import Register from "app/src/components/lv5/Register";
+import SettingProfile from "app/src/components/lv5/SettingProfile";
 
 const Root = () => {
   return (
@@ -12,6 +13,11 @@ const Root = () => {
         <Scene key="sample" component={sample} title="sample" />
         <Scene key="chatroom" component={Chatroom} title="chatroom" />
         <Scene key="register" component={Register} title="新規登録" />
+        <Scene
+          key="settingProfile"
+          component={SettingProfile}
+          title="プロフィール設定"
+        />
       </Stack>
     </Router>
   );

--- a/src/components/lv1/Input.js
+++ b/src/components/lv1/Input.js
@@ -6,7 +6,8 @@ export default ({
   value,
   maxLength,
   keyboardType,
-  onChangeText
+  onChangeText,
+  ...props
 }) => {
   return (
     <TextInput
@@ -15,6 +16,7 @@ export default ({
       maxLength={maxLength}
       keyboardType={keyboardType}
       onChangeText={onChangeText}
+      {...props}
     />
   );
 };

--- a/src/components/lv2/InputWithIcon.js
+++ b/src/components/lv2/InputWithIcon.js
@@ -4,10 +4,10 @@ import Input from "app/src/components/lv1/Input";
 import Icon from "app/src/components/lv1/Icon";
 
 export default props => {
-  const { style, ...props } = props;
+  const { iconName, iconSize, iconColor, ...props } = props;
   return (
-    <View style={style}>
-      <Icon {...props} />
+    <View>
+      <Icon name={iconName} size={iconSize} color={iconColor} />
       <Input {...props} />
     </View>
   );

--- a/src/components/lv5/Register.js
+++ b/src/components/lv5/Register.js
@@ -21,21 +21,25 @@ export default class extends React.Component {
     this.setState({ [target]: text });
   };
 
-  onSend = async () => {
+  onSend = () => {
     const { phoneNumber, countryISO2 } = this.state;
     const { dialCode } = COUNTRY.find(country => country.iso2 === countryISO2);
     const phoneNumberWithDialCode = `+${dialCode} ${phoneNumber}`;
-    // send
-    const confirmationResult = await auth.phoneNumber(phoneNumberWithDialCode);
 
-    this.setState({ confirmationResult });
+    auth
+      .phoneNumber(phoneNumberWithDialCode)
+      .then(confirmationResult => {
+        console.log("SMSを送信しました");
+        this.setState({ confirmationResult });
+      })
+      .catch(e => console.error(e.message));
   };
 
   onConfirm = () => {
     const { confirmationResult, confirmCode } = this.state;
     confirmationResult
       .confirm(confirmCode)
-      .then(res => console.log("singined: ", res.uid))
+      .then(res => console.log("userID: ", res.uid))
       .catch(e => console.log(e.message));
   };
 

--- a/src/components/lv5/Register.js
+++ b/src/components/lv5/Register.js
@@ -2,11 +2,40 @@ import React from "react";
 import { Actions } from "react-native-router-flux";
 import { View, Text, Button } from "react-native";
 
+import PhoneInput from "react-native-phone-input";
+import Input from "app/src/components/lv1/Input";
+
+import COUNTRY from "app/src/config/countries.json";
+
 export default class extends React.Component {
+  state = {
+    phoneNumber: "",
+    countryISO2: "jp"
+  };
+
+  onChangeText = (target, text) => {
+    this.setState({ [target]: text });
+  };
+
+  onSend = () => {
+    const { phoneNumber, countryISO2 } = this.state;
+    const { dialCode } = COUNTRY.find(country => country.iso2 === countryISO2);
+    const phoneNumberWithDialCode = `+${dialCode} ${phoneNumber}`;
+    // send
+  };
+
   render() {
     return (
       <View>
         <Text>新規登録</Text>
+        <PhoneInput
+          initialCountry="jp"
+          ref="phone"
+          onChangePhoneNumber={phoneNumber => this.setState({ phoneNumber })}
+          value={this.state.phoneNumber}
+          onSelectCountry={countryISO2 => this.setState({ countryISO2 })}
+        />
+        <Button title="SMS送信" onPress={this.onSend} />
       </View>
     );
   }

--- a/src/components/lv5/Register.js
+++ b/src/components/lv5/Register.js
@@ -1,13 +1,12 @@
 import React from "react";
 import { Actions } from "react-native-router-flux";
-import { View, Button } from "react-native";
+import { View, Text, Button } from "react-native";
 
 export default class extends React.Component {
   render() {
     return (
       <View>
-        <Button title="Chatroom" onPress={() => Actions.chatroom()} />
-        <Button title="新規登録" onPress={() => Actions.register()} />
+        <Text>新規登録</Text>
       </View>
     );
   }

--- a/src/components/lv5/Register.js
+++ b/src/components/lv5/Register.js
@@ -2,6 +2,8 @@ import React from "react";
 import { Actions } from "react-native-router-flux";
 import { View, Text, Button } from "react-native";
 
+import { auth } from "app/src/utils/firebase";
+
 import PhoneInput from "react-native-phone-input";
 import Input from "app/src/components/lv1/Input";
 
@@ -10,21 +12,35 @@ import COUNTRY from "app/src/config/countries.json";
 export default class extends React.Component {
   state = {
     phoneNumber: "",
-    countryISO2: "jp"
+    countryISO2: "jp",
+    confirmationResult: {},
+    confirmCode: ""
   };
 
   onChangeText = (target, text) => {
     this.setState({ [target]: text });
   };
 
-  onSend = () => {
+  onSend = async () => {
     const { phoneNumber, countryISO2 } = this.state;
     const { dialCode } = COUNTRY.find(country => country.iso2 === countryISO2);
     const phoneNumberWithDialCode = `+${dialCode} ${phoneNumber}`;
     // send
+    const confirmationResult = await auth.phoneNumber(phoneNumberWithDialCode);
+
+    this.setState({ confirmationResult });
+  };
+
+  onConfirm = () => {
+    const { confirmationResult, confirmCode } = this.state;
+    confirmationResult
+      .confirm(confirmCode)
+      .then(res => console.log("singined: ", res.uid))
+      .catch(e => console.log(e.message));
   };
 
   render() {
+    console.log(this.state);
     return (
       <View>
         <Text>新規登録</Text>
@@ -36,6 +52,11 @@ export default class extends React.Component {
           onSelectCountry={countryISO2 => this.setState({ countryISO2 })}
         />
         <Button title="SMS送信" onPress={this.onSend} />
+        <Input
+          onChangeText={text => this.setState({ confirmCode: text })}
+          value={this.state.confirmCode}
+        />
+        <Button title="確認コード送信" onPress={this.onConfirm} />
       </View>
     );
   }

--- a/src/components/lv5/SettingProfile.js
+++ b/src/components/lv5/SettingProfile.js
@@ -1,0 +1,38 @@
+import React from "react";
+import { Actions } from "react-native-router-flux";
+import { View, Text, Button } from "react-native";
+
+import { auth } from "app/src/utils/firebase";
+
+import Input from "app/src/components/lv1/Input";
+
+export default class extends React.Component {
+  state = { userId: "", displayName: "", ptotoUrl: "" };
+
+  componentDidMount() {
+    const userId = auth.currentUserId();
+    this.setState({ userId });
+  }
+
+  onSignOut = () => {
+    auth
+      .signOut()
+      .then(() => Actions.refresh())
+      .catch(e => console.error(e.message));
+  };
+
+  render() {
+    return (
+      <View>
+        {auth.isSignedIn() ? (
+          <>
+            <Text>id: {this.state.userId}</Text>
+            <Button title="ログアウト" onPress={this.onSignOut} />
+          </>
+        ) : (
+          <Text>ログインしてないよ</Text>
+        )}
+      </View>
+    );
+  }
+}

--- a/src/components/lv5/sample.js
+++ b/src/components/lv5/sample.js
@@ -8,6 +8,10 @@ export default class extends React.Component {
       <View>
         <Button title="Chatroom" onPress={() => Actions.chatroom()} />
         <Button title="新規登録" onPress={() => Actions.register()} />
+        <Button
+          title="プロフィール設定"
+          onPress={() => Actions.settingProfile()}
+        />
       </View>
     );
   }

--- a/src/config/countries.json
+++ b/src/config/countries.json
@@ -1,0 +1,1746 @@
+[ 
+  {
+    "name": "Afghanistan (‫افغانستان‬‎)",
+    "iso2": "af",
+    "dialCode": "93",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Albania (Shqipëri)",
+    "iso2": "al",
+    "dialCode": "355",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Algeria (‫الجزائر‬‎)",
+    "iso2": "dz",
+    "dialCode": "213",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "American Samoa",
+    "iso2": "as",
+    "dialCode": "1684",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Andorra",
+    "iso2": "ad",
+    "dialCode": "376",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Angola",
+    "iso2": "ao",
+    "dialCode": "244",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Anguilla",
+    "iso2": "ai",
+    "dialCode": "1264",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Antigua and Barbuda",
+    "iso2": "ag",
+    "dialCode": "1268",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Argentina",
+    "iso2": "ar",
+    "dialCode": "54",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Armenia (Հայաստան)",
+    "iso2": "am",
+    "dialCode": "374",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Aruba",
+    "iso2": "aw",
+    "dialCode": "297",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Australia",
+    "iso2": "au",
+    "dialCode": "61",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Austria (Österreich)",
+    "iso2": "at",
+    "dialCode": "43",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Azerbaijan (Azərbaycan)",
+    "iso2": "az",
+    "dialCode": "994",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Bahamas",
+    "iso2": "bs",
+    "dialCode": "1242",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Bahrain (‫البحرين‬‎)",
+    "iso2": "bh",
+    "dialCode": "973",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Bangladesh (বাংলাদেশ)",
+    "iso2": "bd",
+    "dialCode": "880",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Barbados",
+    "iso2": "bb",
+    "dialCode": "1246",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Belarus (Беларусь)",
+    "iso2": "by",
+    "dialCode": "375",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Belgium (België)",
+    "iso2": "be",
+    "dialCode": "32",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Belize",
+    "iso2": "bz",
+    "dialCode": "501",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Benin (Bénin)",
+    "iso2": "bj",
+    "dialCode": "229",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Bermuda",
+    "iso2": "bm",
+    "dialCode": "1441",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Bhutan (འབྲུག)",
+    "iso2": "bt",
+    "dialCode": "975",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Bolivia",
+    "iso2": "bo",
+    "dialCode": "591",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Bosnia and Herzegovina (Босна и Херцеговина)",
+    "iso2": "ba",
+    "dialCode": "387",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Botswana",
+    "iso2": "bw",
+    "dialCode": "267",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Brazil (Brasil)",
+    "iso2": "br",
+    "dialCode": "55",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "British Indian Ocean Territory",
+    "iso2": "io",
+    "dialCode": "246",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "British Virgin Islands",
+    "iso2": "vg",
+    "dialCode": "1284",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Brunei",
+    "iso2": "bn",
+    "dialCode": "673",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Bulgaria (България)",
+    "iso2": "bg",
+    "dialCode": "359",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Burkina Faso",
+    "iso2": "bf",
+    "dialCode": "226",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Burundi (Uburundi)",
+    "iso2": "bi",
+    "dialCode": "257",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Cambodia (កម្ពុជា)",
+    "iso2": "kh",
+    "dialCode": "855",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Cameroon (Cameroun)",
+    "iso2": "cm",
+    "dialCode": "237",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Canada",
+    "iso2": "ca",
+    "dialCode": "1",
+    "priority": 1,
+    "areaCodes": [
+      "204",
+      "226",
+      "236",
+      "249",
+      "250",
+      "289",
+      "306",
+      "343",
+      "365",
+      "387",
+      "403",
+      "416",
+      "418",
+      "431",
+      "437",
+      "438",
+      "450",
+      "506",
+      "514",
+      "519",
+      "548",
+      "579",
+      "581",
+      "587",
+      "604",
+      "613",
+      "639",
+      "647",
+      "672",
+      "705",
+      "709",
+      "742",
+      "778",
+      "780",
+      "782",
+      "807",
+      "819",
+      "825",
+      "867",
+      "873",
+      "902",
+      "905"
+    ]
+  },
+  {
+    "name": "Cape Verde (Kabu Verdi)",
+    "iso2": "cv",
+    "dialCode": "238",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Caribbean Netherlands",
+    "iso2": "bq",
+    "dialCode": "599",
+    "priority": 1,
+    "areaCodes": null
+  },
+  {
+    "name": "Cayman Islands",
+    "iso2": "ky",
+    "dialCode": "1345",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Central African Republic (République centrafricaine)",
+    "iso2": "cf",
+    "dialCode": "236",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Chad (Tchad)",
+    "iso2": "td",
+    "dialCode": "235",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Chile",
+    "iso2": "cl",
+    "dialCode": "56",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "China (中国)",
+    "iso2": "cn",
+    "dialCode": "86",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Christmas Island",
+    "iso2": "cx",
+    "dialCode": "61",
+    "priority": 2,
+    "areaCodes": null
+  },
+  {
+    "name": "Cocos (Keeling) Islands",
+    "iso2": "cc",
+    "dialCode": "61",
+    "priority": 1,
+    "areaCodes": null
+  },
+  {
+    "name": "Colombia",
+    "iso2": "co",
+    "dialCode": "57",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Comoros (‫جزر القمر‬‎)",
+    "iso2": "km",
+    "dialCode": "269",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Congo (DRC) (Jamhuri ya Kidemokrasia ya Kongo)",
+    "iso2": "cd",
+    "dialCode": "243",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Congo (Republic) (Congo-Brazzaville)",
+    "iso2": "cg",
+    "dialCode": "242",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Cook Islands",
+    "iso2": "ck",
+    "dialCode": "682",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Costa Rica",
+    "iso2": "cr",
+    "dialCode": "506",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Côte d’Ivoire",
+    "iso2": "ci",
+    "dialCode": "225",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Croatia (Hrvatska)",
+    "iso2": "hr",
+    "dialCode": "385",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Cuba",
+    "iso2": "cu",
+    "dialCode": "53",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Curaçao",
+    "iso2": "cw",
+    "dialCode": "599",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Cyprus (Κύπρος)",
+    "iso2": "cy",
+    "dialCode": "357",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Czech Republic (Česká republika)",
+    "iso2": "cz",
+    "dialCode": "420",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Denmark (Danmark)",
+    "iso2": "dk",
+    "dialCode": "45",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Djibouti",
+    "iso2": "dj",
+    "dialCode": "253",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Dominica",
+    "iso2": "dm",
+    "dialCode": "1767",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Dominican Republic (República Dominicana)",
+    "iso2": "do",
+    "dialCode": "1",
+    "priority": 2,
+    "areaCodes": [
+      "809",
+      "829",
+      "849"
+    ]
+  },
+  {
+    "name": "Ecuador",
+    "iso2": "ec",
+    "dialCode": "593",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Egypt (‫مصر‬‎)",
+    "iso2": "eg",
+    "dialCode": "20",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "El Salvador",
+    "iso2": "sv",
+    "dialCode": "503",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Equatorial Guinea (Guinea Ecuatorial)",
+    "iso2": "gq",
+    "dialCode": "240",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Eritrea",
+    "iso2": "er",
+    "dialCode": "291",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Estonia (Eesti)",
+    "iso2": "ee",
+    "dialCode": "372",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Ethiopia",
+    "iso2": "et",
+    "dialCode": "251",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Falkland Islands (Islas Malvinas)",
+    "iso2": "fk",
+    "dialCode": "500",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Faroe Islands (Føroyar)",
+    "iso2": "fo",
+    "dialCode": "298",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Fiji",
+    "iso2": "fj",
+    "dialCode": "679",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Finland (Suomi)",
+    "iso2": "fi",
+    "dialCode": "358",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "France",
+    "iso2": "fr",
+    "dialCode": "33",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "French Guiana (Guyane française)",
+    "iso2": "gf",
+    "dialCode": "594",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "French Polynesia (Polynésie française)",
+    "iso2": "pf",
+    "dialCode": "689",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Gabon",
+    "iso2": "ga",
+    "dialCode": "241",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Gambia",
+    "iso2": "gm",
+    "dialCode": "220",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Georgia (საქართველო)",
+    "iso2": "ge",
+    "dialCode": "995",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Germany (Deutschland)",
+    "iso2": "de",
+    "dialCode": "49",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Ghana (Gaana)",
+    "iso2": "gh",
+    "dialCode": "233",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Gibraltar",
+    "iso2": "gi",
+    "dialCode": "350",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Greece (Ελλάδα)",
+    "iso2": "gr",
+    "dialCode": "30",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Greenland (Kalaallit Nunaat)",
+    "iso2": "gl",
+    "dialCode": "299",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Grenada",
+    "iso2": "gd",
+    "dialCode": "1473",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Guadeloupe",
+    "iso2": "gp",
+    "dialCode": "590",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Guam",
+    "iso2": "gu",
+    "dialCode": "1671",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Guatemala",
+    "iso2": "gt",
+    "dialCode": "502",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Guernsey",
+    "iso2": "gg",
+    "dialCode": "44",
+    "priority": 1,
+    "areaCodes": null
+  },
+  {
+    "name": "Guinea (Guinée)",
+    "iso2": "gn",
+    "dialCode": "224",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Guinea-Bissau (Guiné Bissau)",
+    "iso2": "gw",
+    "dialCode": "245",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Guyana",
+    "iso2": "gy",
+    "dialCode": "592",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Haiti",
+    "iso2": "ht",
+    "dialCode": "509",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Honduras",
+    "iso2": "hn",
+    "dialCode": "504",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Hong Kong (香港)",
+    "iso2": "hk",
+    "dialCode": "852",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Hungary (Magyarország)",
+    "iso2": "hu",
+    "dialCode": "36",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Iceland (Ísland)",
+    "iso2": "is",
+    "dialCode": "354",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "India (भारत)",
+    "iso2": "in",
+    "dialCode": "91",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Indonesia",
+    "iso2": "id",
+    "dialCode": "62",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Iran (‫ایران‬‎)",
+    "iso2": "ir",
+    "dialCode": "98",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Iraq (‫العراق‬‎)",
+    "iso2": "iq",
+    "dialCode": "964",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Ireland",
+    "iso2": "ie",
+    "dialCode": "353",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Isle of Man",
+    "iso2": "im",
+    "dialCode": "44",
+    "priority": 2,
+    "areaCodes": null
+  },
+  {
+    "name": "Israel (‫ישראל‬‎)",
+    "iso2": "il",
+    "dialCode": "972",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Italy (Italia)",
+    "iso2": "it",
+    "dialCode": "39",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Jamaica",
+    "iso2": "jm",
+    "dialCode": "1876",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Japan (日本)",
+    "iso2": "jp",
+    "dialCode": "81",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Jersey",
+    "iso2": "je",
+    "dialCode": "44",
+    "priority": 3,
+    "areaCodes": null
+  },
+  {
+    "name": "Jordan (‫الأردن‬‎)",
+    "iso2": "jo",
+    "dialCode": "962",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Kazakhstan (Казахстан)",
+    "iso2": "kz",
+    "dialCode": "7",
+    "priority": 1,
+    "areaCodes": null
+  },
+  {
+    "name": "Kenya",
+    "iso2": "ke",
+    "dialCode": "254",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Kiribati",
+    "iso2": "ki",
+    "dialCode": "686",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Kuwait (‫الكويت‬‎)",
+    "iso2": "kw",
+    "dialCode": "965",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Kyrgyzstan (Кыргызстан)",
+    "iso2": "kg",
+    "dialCode": "996",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Laos (ລາວ)",
+    "iso2": "la",
+    "dialCode": "856",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Latvia (Latvija)",
+    "iso2": "lv",
+    "dialCode": "371",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Lebanon (‫لبنان‬‎)",
+    "iso2": "lb",
+    "dialCode": "961",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Lesotho",
+    "iso2": "ls",
+    "dialCode": "266",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Liberia",
+    "iso2": "lr",
+    "dialCode": "231",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Libya (‫ليبيا‬‎)",
+    "iso2": "ly",
+    "dialCode": "218",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Liechtenstein",
+    "iso2": "li",
+    "dialCode": "423",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Lithuania (Lietuva)",
+    "iso2": "lt",
+    "dialCode": "370",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Luxembourg",
+    "iso2": "lu",
+    "dialCode": "352",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Macau (澳門)",
+    "iso2": "mo",
+    "dialCode": "853",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Macedonia (FYROM) (Македонија)",
+    "iso2": "mk",
+    "dialCode": "389",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Madagascar (Madagasikara)",
+    "iso2": "mg",
+    "dialCode": "261",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Malawi",
+    "iso2": "mw",
+    "dialCode": "265",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Malaysia",
+    "iso2": "my",
+    "dialCode": "60",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Maldives",
+    "iso2": "mv",
+    "dialCode": "960",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Mali",
+    "iso2": "ml",
+    "dialCode": "223",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Malta",
+    "iso2": "mt",
+    "dialCode": "356",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Marshall Islands",
+    "iso2": "mh",
+    "dialCode": "692",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Martinique",
+    "iso2": "mq",
+    "dialCode": "596",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Mauritania (‫موريتانيا‬‎)",
+    "iso2": "mr",
+    "dialCode": "222",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Mauritius (Moris)",
+    "iso2": "mu",
+    "dialCode": "230",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Mayotte",
+    "iso2": "yt",
+    "dialCode": "262",
+    "priority": 1,
+    "areaCodes": null
+  },
+  {
+    "name": "Mexico (México)",
+    "iso2": "mx",
+    "dialCode": "52",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Micronesia",
+    "iso2": "fm",
+    "dialCode": "691",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Moldova (Republica Moldova)",
+    "iso2": "md",
+    "dialCode": "373",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Monaco",
+    "iso2": "mc",
+    "dialCode": "377",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Mongolia (Монгол)",
+    "iso2": "mn",
+    "dialCode": "976",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Montenegro (Crna Gora)",
+    "iso2": "me",
+    "dialCode": "382",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Montserrat",
+    "iso2": "ms",
+    "dialCode": "1664",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Morocco (‫المغرب‬‎)",
+    "iso2": "ma",
+    "dialCode": "212",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Mozambique (Moçambique)",
+    "iso2": "mz",
+    "dialCode": "258",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Myanmar (Burma)",
+    "iso2": "mm",
+    "dialCode": "95",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Namibia (Namibië)",
+    "iso2": "na",
+    "dialCode": "264",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Nauru",
+    "iso2": "nr",
+    "dialCode": "674",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Nepal (नेपाल)",
+    "iso2": "np",
+    "dialCode": "977",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Netherlands (Nederland)",
+    "iso2": "nl",
+    "dialCode": "31",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "New Caledonia (Nouvelle-Calédonie)",
+    "iso2": "nc",
+    "dialCode": "687",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "New Zealand",
+    "iso2": "nz",
+    "dialCode": "64",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Nicaragua",
+    "iso2": "ni",
+    "dialCode": "505",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Niger (Nijar)",
+    "iso2": "ne",
+    "dialCode": "227",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Nigeria",
+    "iso2": "ng",
+    "dialCode": "234",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Niue",
+    "iso2": "nu",
+    "dialCode": "683",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Norfolk Island",
+    "iso2": "nf",
+    "dialCode": "672",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "North Korea (조선 민주주의 인민 공화국)",
+    "iso2": "kp",
+    "dialCode": "850",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Northern Mariana Islands",
+    "iso2": "mp",
+    "dialCode": "1670",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Norway (Norge)",
+    "iso2": "no",
+    "dialCode": "47",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Oman (‫عُمان‬‎)",
+    "iso2": "om",
+    "dialCode": "968",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Pakistan (‫پاکستان‬‎)",
+    "iso2": "pk",
+    "dialCode": "92",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Palau",
+    "iso2": "pw",
+    "dialCode": "680",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Palestine (‫فلسطين‬‎)",
+    "iso2": "ps",
+    "dialCode": "970",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Panama (Panamá)",
+    "iso2": "pa",
+    "dialCode": "507",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Papua New Guinea",
+    "iso2": "pg",
+    "dialCode": "675",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Paraguay",
+    "iso2": "py",
+    "dialCode": "595",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Peru (Perú)",
+    "iso2": "pe",
+    "dialCode": "51",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Philippines",
+    "iso2": "ph",
+    "dialCode": "63",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Poland (Polska)",
+    "iso2": "pl",
+    "dialCode": "48",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Portugal",
+    "iso2": "pt",
+    "dialCode": "351",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Puerto Rico",
+    "iso2": "pr",
+    "dialCode": "1",
+    "priority": 3,
+    "areaCodes": [
+      "787",
+      "939"
+    ]
+  },
+  {
+    "name": "Qatar (‫قطر‬‎)",
+    "iso2": "qa",
+    "dialCode": "974",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Réunion (La Réunion)",
+    "iso2": "re",
+    "dialCode": "262",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Romania (România)",
+    "iso2": "ro",
+    "dialCode": "40",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Russia (Россия)",
+    "iso2": "ru",
+    "dialCode": "7",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Rwanda",
+    "iso2": "rw",
+    "dialCode": "250",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Saint Barthélemy (Saint-Barthélemy)",
+    "iso2": "bl",
+    "dialCode": "590",
+    "priority": 1,
+    "areaCodes": null
+  },
+  {
+    "name": "Saint Helena",
+    "iso2": "sh",
+    "dialCode": "290",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Saint Kitts and Nevis",
+    "iso2": "kn",
+    "dialCode": "1869",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Saint Lucia",
+    "iso2": "lc",
+    "dialCode": "1758",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Saint Martin (Saint-Martin (partie française))",
+    "iso2": "mf",
+    "dialCode": "590",
+    "priority": 2,
+    "areaCodes": null
+  },
+  {
+    "name": "Saint Pierre and Miquelon (Saint-Pierre-et-Miquelon)",
+    "iso2": "pm",
+    "dialCode": "508",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Saint Vincent and the Grenadines",
+    "iso2": "vc",
+    "dialCode": "1784",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Samoa",
+    "iso2": "ws",
+    "dialCode": "685",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "San Marino",
+    "iso2": "sm",
+    "dialCode": "378",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "São Tomé and Príncipe (São Tomé e Príncipe)",
+    "iso2": "st",
+    "dialCode": "239",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Saudi Arabia (‫المملكة العربية السعودية‬‎)",
+    "iso2": "sa",
+    "dialCode": "966",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Senegal (Sénégal)",
+    "iso2": "sn",
+    "dialCode": "221",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Serbia (Србија)",
+    "iso2": "rs",
+    "dialCode": "381",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Seychelles",
+    "iso2": "sc",
+    "dialCode": "248",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Sierra Leone",
+    "iso2": "sl",
+    "dialCode": "232",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Singapore",
+    "iso2": "sg",
+    "dialCode": "65",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Sint Maarten",
+    "iso2": "sx",
+    "dialCode": "1721",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Slovakia (Slovensko)",
+    "iso2": "sk",
+    "dialCode": "421",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Slovenia (Slovenija)",
+    "iso2": "si",
+    "dialCode": "386",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Solomon Islands",
+    "iso2": "sb",
+    "dialCode": "677",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Somalia (Soomaaliya)",
+    "iso2": "so",
+    "dialCode": "252",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "South Africa",
+    "iso2": "za",
+    "dialCode": "27",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "South Korea (대한민국)",
+    "iso2": "kr",
+    "dialCode": "82",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "South Sudan (‫جنوب السودان‬‎)",
+    "iso2": "ss",
+    "dialCode": "211",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Spain (España)",
+    "iso2": "es",
+    "dialCode": "34",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Sri Lanka (ශ්‍රී ලංකාව)",
+    "iso2": "lk",
+    "dialCode": "94",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Sudan (‫السودان‬‎)",
+    "iso2": "sd",
+    "dialCode": "249",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Suriname",
+    "iso2": "sr",
+    "dialCode": "597",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Svalbard and Jan Mayen",
+    "iso2": "sj",
+    "dialCode": "47",
+    "priority": 1,
+    "areaCodes": null
+  },
+  {
+    "name": "Swaziland",
+    "iso2": "sz",
+    "dialCode": "268",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Sweden (Sverige)",
+    "iso2": "se",
+    "dialCode": "46",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Switzerland (Schweiz)",
+    "iso2": "ch",
+    "dialCode": "41",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Syria (‫سوريا‬‎)",
+    "iso2": "sy",
+    "dialCode": "963",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Taiwan (台灣)",
+    "iso2": "tw",
+    "dialCode": "886",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Tajikistan",
+    "iso2": "tj",
+    "dialCode": "992",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Tanzania",
+    "iso2": "tz",
+    "dialCode": "255",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Thailand (ไทย)",
+    "iso2": "th",
+    "dialCode": "66",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Timor-Leste",
+    "iso2": "tl",
+    "dialCode": "670",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Togo",
+    "iso2": "tg",
+    "dialCode": "228",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Tokelau",
+    "iso2": "tk",
+    "dialCode": "690",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Tonga",
+    "iso2": "to",
+    "dialCode": "676",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Trinidad and Tobago",
+    "iso2": "tt",
+    "dialCode": "1868",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Tunisia (‫تونس‬‎)",
+    "iso2": "tn",
+    "dialCode": "216",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Turkey (Türkiye)",
+    "iso2": "tr",
+    "dialCode": "90",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Turkmenistan",
+    "iso2": "tm",
+    "dialCode": "993",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Turks and Caicos Islands",
+    "iso2": "tc",
+    "dialCode": "1649",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Tuvalu",
+    "iso2": "tv",
+    "dialCode": "688",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "U.S. Virgin Islands",
+    "iso2": "vi",
+    "dialCode": "1340",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Uganda",
+    "iso2": "ug",
+    "dialCode": "256",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Ukraine (Україна)",
+    "iso2": "ua",
+    "dialCode": "380",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "United Arab Emirates (‫الإمارات العربية المتحدة‬‎)",
+    "iso2": "ae",
+    "dialCode": "971",
+    "priority": 0,
+    "areaCodes": null
+  },  
+  {
+    "name": "United Kingdom",
+    "iso2": "gb",
+    "dialCode": "44",
+    "priority": 0,
+    "areaCodes": null
+  },
+    {
+    "name": "United States",
+    "iso2": "us",
+    "dialCode": "1",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Uruguay",
+    "iso2": "uy",
+    "dialCode": "598",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Uzbekistan (Oʻzbekiston)",
+    "iso2": "uz",
+    "dialCode": "998",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Vanuatu",
+    "iso2": "vu",
+    "dialCode": "678",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Vatican City (Città del Vaticano)",
+    "iso2": "va",
+    "dialCode": "39",
+    "priority": 1,
+    "areaCodes": null
+  },
+  {
+    "name": "Venezuela",
+    "iso2": "ve",
+    "dialCode": "58",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Vietnam (Việt Nam)",
+    "iso2": "vn",
+    "dialCode": "84",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Wallis and Futuna",
+    "iso2": "wf",
+    "dialCode": "681",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Western Sahara (‫الصحراء الغربية‬‎)",
+    "iso2": "eh",
+    "dialCode": "212",
+    "priority": 1,
+    "areaCodes": null
+  },
+  {
+    "name": "Yemen (‫اليمن‬‎)",
+    "iso2": "ye",
+    "dialCode": "967",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Zambia",
+    "iso2": "zm",
+    "dialCode": "260",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Zimbabwe",
+    "iso2": "zw",
+    "dialCode": "263",
+    "priority": 0,
+    "areaCodes": null
+  },
+  {
+    "name": "Åland Islands",
+    "iso2": "ax",
+    "dialCode": "358",
+    "priority": 1,
+    "areaCodes": null
+  }
+]

--- a/src/utils/firebase.js
+++ b/src/utils/firebase.js
@@ -10,8 +10,19 @@ export const auth = {
       .auth()
       .signInWithPhoneNumber(phoneNumber)
       .catch(e => console.error(e.message));
-    console.log("ok");
     return confirmationResult;
+  },
+  signOut: async () => {
+    const req = await firebase.auth().signOut();
+    return req;
+  },
+  currentUserId: () => {
+    const currentUser = firebase.auth().currentUser;
+    return currentUser ? currentUser.uid : "";
+  },
+  isSignedIn: () => {
+    const currentUser = firebase.auth().currentUser;
+    return !!currentUser;
   }
 };
 

--- a/src/utils/firebase.js
+++ b/src/utils/firebase.js
@@ -4,14 +4,15 @@ export default firebase;
 
 export const db = firebase.firestore();
 
-export const test = () => {
-  firebase
-    .auth()
-    .signInAnonymously()
-    .then(user => {
-      console.log(user.isAnonymous);
-      console.log("ok");
-    });
+export const auth = {
+  phoneNumber: async phoneNumber => {
+    const confirmationResult = await firebase
+      .auth()
+      .signInWithPhoneNumber(phoneNumber)
+      .catch(e => console.error(e.message));
+    console.log("ok");
+    return confirmationResult;
+  }
 };
 
 export const storage = firebase.storage();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2892,6 +2892,11 @@ globals@^11.1.0, globals@^11.7.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
+google-libphonenumber@^3.2.2:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/google-libphonenumber/-/google-libphonenumber-3.2.5.tgz#2ebe6437fd3dbbffd65f4339ad1ba93b3dc56836"
+  integrity sha512-Y0r7MFCI11UDLn0KaMPBEInhROyIOkWkQIyvWMFVF2I+h+sHE3vbl5a7FVe39td6u/w+nlKDdUMP9dMOZyv+2Q==
+
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
@@ -4082,7 +4087,7 @@ lodash.unescape@4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
   integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
 
-lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.5, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -5367,10 +5372,19 @@ react-native-maps@~0.25.0:
   resolved "https://registry.yarnpkg.com/react-native-maps/-/react-native-maps-0.25.0.tgz#81bc51eb50e33811a9e1c345cc48869413ead67d"
   integrity sha512-PFJuW1pt+HnnnN0m0OGk29RSvICFVkK/DScX6cUk0SuCSN2DAHx0y6y57lZyYXcYqU4J4usNpfxgp/ccjASDiw==
 
-"react-native-parsed-text@git+https://github.com/EvanBacon/react-native-parsed-text.git":
+"react-native-parsed-text@https://github.com/EvanBacon/react-native-parsed-text.git":
   version "0.0.22"
-  resolved "git+https://github.com/EvanBacon/react-native-parsed-text.git#24939951b13a8223882c74610d758903eed652ab"
+  resolved "https://github.com/EvanBacon/react-native-parsed-text.git#24939951b13a8223882c74610d758903eed652ab"
   dependencies:
+    prop-types "^15.5.10"
+
+react-native-phone-input@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/react-native-phone-input/-/react-native-phone-input-0.2.4.tgz#32be251fa57dd73eccef0d4e10d13b17a718505d"
+  integrity sha512-NSfiY0ZyyLFRmem2x14Hdnd0tSMYEDX05B7rWXcfw/ulB2jdlXgili2xRNMwV6aZVWFfcKBJAGNi0Vxc6L1fLw==
+  dependencies:
+    google-libphonenumber "^3.2.2"
+    lodash "^4.17.4"
     prop-types "^15.5.10"
 
 react-native-router-flux@^4.0.6:


### PR DESCRIPTION
## 電話番号認証機能

電話番号の入力は国番号が面倒だったので`react-native-phone-input`モジュール
> https://github.com/thegamenicorus/react-native-phone-input
を使用しました。

テスト方法
1. firebaseコンソールサイドバーAuthentication>ログイン方法タブ>電話番号のテスト用電話番号に追加
2. 新規登録画面でテスト用に追加した電話番号を入力
3. 確認番号にテスト用に追加した確認番号を入力

## ユーザプロフィールについて

表示名と画像URLの項目しかいじれなかったのでfirestoreでUIDと紐付けて管理します。

## その他

APNsはxcodeで有効化する際にappleIDの認証が必要なため、やってほしいです。また、実機でないとテストできないので取り急ぎ対応が必要（本番でも実機デモで使うだろうから、俺の方ではできないからどっちかにお願いしたい）

・現在ログインしているユーザのUIDを取得
・ログアウト
・ログインしているかどうかをboolで返す
の３つを実装済み